### PR TITLE
Get can now handle page tokens

### DIFF
--- a/lib/get.js
+++ b/lib/get.js
@@ -4,20 +4,27 @@ var get = function ( options ) {
 
     var getToken = require('./getToken')(options.iss, options.key);
 
-    return function ( url, cb ) {
+    return function ( url, nextPageToken, cb ) {
+        if (typeof nextPageToken === 'function') {
+            cb = nextPageToken;
+            delete nextPageToken;
+        }
 
         getToken(function ( err, token ) {
-            
             if (err) { return cb(err); }
             console.log('requesting to: ' + url);
 
-            request.get({
+            var getParams = {
                 url: 'https://www.googleapis.com/bigquery/v2' + url,
                 qs: {
                     access_token: token
                 }
-            }, function ( err, res, body ) {
-                
+            }
+            if (nextPageToken) {
+                getParams.qs.pageToken = nextPageToken;
+            }
+
+            request.get(getParams , function ( err, res, body ) {
                 if ( err || res.statusCode !== 200 ) {
                     //console.log(err || res);
                     cb('there was a problem executing your query');


### PR DESCRIPTION
I added some code on how to do it to the get.js file. Not sure how you wanna include it, but this would allow for someone to pass in a token to get the next result and make the paging their problem for now.
